### PR TITLE
Add support for no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ readme = "README.md"
 description = """
 Runtime-checked borrow lifetimes.
 """
+
+[features]
+default = ["std"]
+std = []


### PR DESCRIPTION
This PR adds optional support for `no_std` by disabling a new default feature, `std`. Mostly the imports are just directed from `std` to `alloc` and `core`. For the `panic_abort` function, `std::process::abort` is used if `feature = "std"` is enabled. For a `no_std` environment with `not(panic = "abort")`, panicking inside a panic is used to produce an abort.